### PR TITLE
Custom Request Limiter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,72 @@
-### Route: http://localhost:8080/urls
+# Simple Request Limiter
 
-### example of body in POST request that was used:
+## Installation
 
+1. Clone this repository
+
+2. Run `go mod download`
+
+## Example
+
+### Run example
+
+Try to hit this endpoint: `POST` http://localhost:8080/urls
+
+with request
+
+```json
 {
     "urls": "https://google.com\r\nhttps://google.com\r\nhttps://google.com\r\nhttps://google.com\r\nhttps://google.com"
 }
+```
 
-### example of response:
+and you will get this response
 
+```json
 {
     "data": "17cdc549e3a685778c55026cd29a9e4a13d4aaa1\r\n453df402bcfb8c64704dd1eb5cc62e3288d9d751\r\nd9d5871b2baec3da9f7e62b1eb68e1b5ac27ba33\r\nba666440b85ecdbedf1abee912d7c07f79d0713b\r\n4ada1814d7e627e60665011f361a5b7acae82abd",
     "message": "Status OK"
 }
+```
+
+If your request got a limitation, you will get the "too many request" response by default.
+
+### Custom Request Limiter
+
+Limit all incoming request
+
+```go
+reqIPLimiter := limiter.NewRequestLimitService(10*time.Second, 100, nil)
+
+http.HandleFunc("/resources", reqIPLimiter.Limit(resourcesHandler))
+```
+
+You can write your own limiter function. Here is example to limit request per IP
+
+```go
+reqIPLimiter := limiter.NewRequestLimitService(10*time.Second, 100, func(r *http.Request) string {
+    return r.RemoteAddr
+})
+
+http.HandleFunc("/resources", reqIPLimiter.Limit(resourcesHandler))
+```
+
+Another example is limit request by session id that stored in cookie:
+
+```go
+reqSessionLimiter := limiter.NewRequestLimitService(10*time.Second, 100, func(r *http.Request) string {
+    return r.Cookie("Session-ID")
+})
+
+http.HandleFunc("/resources", reqIPLimiter.Limit(resourcesHandler))
+```
+
+### Custom Blocked Request Handler
+
+You can use your own response handler when current request is blocked
+
+```go
+limiter.OnTooManyRequest(func(w http.ResponseWriter, r *http.Request) {
+    http.Error(w, "please try again later", http.StatusTooManyRequest)
+})
+```

--- a/limiter/group_limit.go
+++ b/limiter/group_limit.go
@@ -1,0 +1,24 @@
+package limiter
+
+import "time"
+
+type groupLimit struct {
+	reqCount int
+	resetAt  time.Time
+}
+
+func newGroupLimit(interval time.Duration) *groupLimit {
+	return &groupLimit{
+		reqCount: 0,
+		resetAt:  time.Now().Add(interval),
+	}
+}
+
+func (m *groupLimit) isStale() bool {
+	return m.resetAt.Before(time.Now())
+}
+
+func (m *groupLimit) refresh(interval time.Duration) {
+	m.reqCount = 0
+	m.resetAt = time.Now().Add(interval)
+}

--- a/limiter/limiter.go
+++ b/limiter/limiter.go
@@ -1,46 +1,78 @@
 package limiter
 
 import (
+	"net/http"
 	"sync"
 	"time"
 )
 
+type IndicatorGetter func(r *http.Request) string
+
 type RequestLimitService struct {
-	Interval time.Duration
-	MaxCount int
-	Lock     sync.Mutex
-	ReqCount int
+	Interval       time.Duration
+	MaxCount       int
+	Lock           sync.Mutex
+	limitIndicator IndicatorGetter
+	limitTable     map[string]*groupLimit
+	errorHandler   http.HandlerFunc
 }
 
-func NewRequestLimitService(interval time.Duration, maxCnt int) *RequestLimitService {
-	reqLimit := &RequestLimitService{
-		Interval: interval,
-		MaxCount: maxCnt,
+func NewRequestLimitService(interval time.Duration, maxCnt int, limitIndicator IndicatorGetter) *RequestLimitService {
+	return &RequestLimitService{
+		Interval:       interval,
+		MaxCount:       maxCnt,
+		limitIndicator: limitIndicator,
+		limitTable:     make(map[string]*groupLimit),
+		errorHandler:   nil,
+	}
+}
+
+func (reqLimit *RequestLimitService) isAllowed(indicator string) bool {
+	reqLimit.Lock.Lock()
+	defer reqLimit.Lock.Unlock()
+
+	group, ok := reqLimit.limitTable[indicator]
+	if !ok {
+		group = newGroupLimit(reqLimit.Interval)
+		reqLimit.limitTable[indicator] = group
 	}
 
-	go func() {
-		ticker := time.NewTicker(interval)
-		for {
-			<-ticker.C
-			reqLimit.Lock.Lock()
-			reqLimit.ReqCount = 0
-			reqLimit.Lock.Unlock()
+	if group.isStale() {
+		group.refresh(reqLimit.Interval)
+	}
+
+	group.reqCount++
+	return group.reqCount <= reqLimit.MaxCount
+}
+
+func (reqLimit *RequestLimitService) defaultErrorHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "too many requests", http.StatusTooManyRequests)
+	}
+}
+
+func (reqLimit *RequestLimitService) OnLimitReached(errorHandler http.HandlerFunc) {
+	reqLimit.errorHandler = errorHandler
+}
+
+func (reqLimit *RequestLimitService) Limit(next http.HandlerFunc) http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var indicator string
+
+		if reqLimit.limitIndicator != nil {
+			indicator = reqLimit.limitIndicator(r)
 		}
-	}()
 
-	return reqLimit
-}
+		if !reqLimit.isAllowed(indicator) {
+			if reqLimit.errorHandler != nil {
+				reqLimit.errorHandler.ServeHTTP(w, r)
+				return
+			}
 
-func (reqLimit *RequestLimitService) Increase() {
-	reqLimit.Lock.Lock()
-	defer reqLimit.Lock.Unlock()
+			reqLimit.defaultErrorHandler().ServeHTTP(w, r)
+			return
+		}
 
-	reqLimit.ReqCount += 1
-}
-
-func (reqLimit *RequestLimitService) IsAvailable() bool {
-	reqLimit.Lock.Lock()
-	defer reqLimit.Lock.Unlock()
-
-	return reqLimit.ReqCount < reqLimit.MaxCount
+		next.ServeHTTP(w, r)
+	})
 }


### PR DESCRIPTION
## Idea

User will be able to write their own limiter function. Here is example to limit 100 request per IP for 10s

```go
reqIPLimiter := limiter.NewRequestLimitService(10*time.Second, 100, func(r *http.Request) string {
    return r.RemoteAddr
})

http.HandleFunc("/resources", reqIPLimiter.Limit(resourcesHandler))
```

Another example is limit request by session id that stored in cookie:

```go
reqSessionLimiter := limiter.NewRequestLimitService(10*time.Second, 100, func(r *http.Request) string {
    return r.Cookie("Session-ID")
})

http.HandleFunc("/resources", reqIPLimiter.Limit(resourcesHandler))
```

The default behavior (limit all request) can be achieved this way:

```go
reqIPLimiter := limiter.NewRequestLimitService(10*time.Second, 100, nil)

http.HandleFunc("/resources", reqIPLimiter.Limit(resourcesHandler))
```

And also user will be able to write their own response handler when current request is blocked

```go
limiter.OnTooManyRequest(func(w http.ResponseWriter, r *http.Request) {
    http.Error(w, "please try again later", http.StatusTooManyRequest)
})
```